### PR TITLE
Subscribe by default to 'all', add discover

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,6 @@ Once installed, you should be able to ping your Raspberry Pi by `ping raspberryp
 
 `bin/signalk-test localhost 3000` will try to connect directly to the specified address.
 
+An optional third command line parameter will be used as the `?suscribe=` parameter in [delta connection url](http://signalk.org/specification/master/streaming_api.html). The default is `all`.
+
 Test client uses [debug](https://www.npmjs.com/package/debug) for logging. You can enable logging by setting the environment variable `DEBUG` to `signalk:*`.

--- a/bin/discover
+++ b/bin/discover
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright 2017 Teppo Kurki <teppo.kurki@iki.fi>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+var signalk_client = require("signalk-client");
+var client = new signalk_client.Client();
+
+client.on('discovery', discovery => {
+  console.log(JSON.stringify(discovery, null, 2))
+})
+
+client.startDiscovery().then((discovery) => {
+  console.log("From Promise:" + JSON.stringify(discovery, null, 2))
+})

--- a/bin/signalk-test
+++ b/bin/signalk-test
@@ -64,12 +64,17 @@ var options = {
   },
   onError: function(error) {
     console.log(error);
-  }
+  },
+  subscribe: "all"
+
 };
 
 if (args.length === 2) {
   options.hostname = args[0];
   options.port = args[1];
+}
+if (args.length === 3) {
+  subscribe = args[2]
 }
 
 client.connect(options);


### PR DESCRIPTION
testclient is behind the times and doesn't use any `subscribe` parameter for deltas.

This PR adds support for passing the subscribe parameter as the third command line parameter and by defaults testclient subscribes to all.